### PR TITLE
update to 1.3.0, switch to compiled build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "unicorn-binance-trailing-stop-loss" %}
-{% set version = "0.8.0" %}
+{% set version = "1.3.0" %}
 
 
 package:
@@ -7,27 +7,30 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/unicorn-binance-trailing-stop-loss-{{ version }}.tar.gz
-  sha256: 643f890b8cee206b49172c697ea563c181f887d82a9e4d20375a494931b4493a
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/unicorn_binance_trailing_stop_loss-{{ version }}.tar.gz
+  sha256: c25ced78cb26da5eb849d0a5eedce8f972be04e9ba6a7ac91c43e6cc8c9bf96a
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
   host:
+    - python
     - pip
-    - python >=3.7
-    - requests
-    - unicorn-binance-rest-api
-    - unicorn-binance-websocket-api
+    - setuptools
+    - wheel
+    - cython
+    - mypy
   run:
-    - python >=3.7
+    - python
+    - cython
     - requests
-    - ubtsl
-    - unicorn-binance-rest-api
-    - unicorn-binance-websocket-api
+    - unicorn-binance-websocket-api >=2.1.1
+    - unicorn-binance-rest-api >=2.2.0
 
 test:
   imports:
@@ -38,16 +41,17 @@ test:
     - pip
 
 about:
-  home: https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html
-  summary: A Python library with a command line interface for a trailing stop loss on Binance Exchange.
+  home: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
+  summary: A Python library with a CLI for a trailing stop loss on Binance.
   description: |
-    A Python library with a command line interface for a trailing stop loss and smart entry on the Binance exchange. 
+    A Python library with a command line interface for a trailing stop loss
+    and smart entry on the Binance exchange. Part of the UNICORN Binance
+    Suite.
   license: MIT
   license_file: LICENSE
-  dev_url: https://github.com/LUCIT-Systems-and-Development/unicorn-binance-trailing-stop-loss
-  doc_url: https://unicorn-binance-trailing-stop-loss.docs.lucit.tech
+  dev_url: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
+  doc_url: https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss
 
 extra:
   recipe-maintainers:
     - oliver-zehentleitner
-


### PR DESCRIPTION
## Update unicorn-binance-trailing-stop-loss to 1.3.0

### Changes
- Bump version 0.8.0 → 1.3.0
- Drop \`noarch: python\` — package now ships compiled Cython C extensions
- Add \`{{ compiler('c') }}\` + \`{{ stdlib('c') }}\` to build requirements
- Add \`cython\` and \`mypy\` to host (cythonize + stubgen run during build)
- Drop bogus \`ubtsl\` runtime dep (no such package on conda-forge)
- Update URLs to current upstream repo

### Dependencies
Requires \`unicorn-binance-websocket-api>=2.1.1\` and \`unicorn-binance-rest-api>=2.2.0\`.
Both available on conda-forge (UBRA 2.10.0 in #23, UBWA 2.12.0 in #32, both merged).

### Rerender note
\`@conda-forge-admin, please rerender\`