### PR TITLE
update to 1.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "unicorn-binance-trailing-stop-loss" %}
-{% set version = "1.3.0" %}
+{% set version = "1.3.1" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/unicorn_binance_trailing_stop_loss-{{ version }}.tar.gz
-  sha256: c25ced78cb26da5eb849d0a5eedce8f972be04e9ba6a7ac91c43e6cc8c9bf96a
+  sha256: d526603535789ae6b510676fb5425ef42e53274dcf6a3834d3c77cbdef839187
 
 build:
   number: 0
@@ -29,7 +29,7 @@ requirements:
     - python
     - cython
     - requests
-    - unicorn-binance-websocket-api >=2.1.1
+    - unicorn-binance-websocket-api >=2.12.2
     - unicorn-binance-rest-api >=2.2.0
 
 test:


### PR DESCRIPTION
Bump version 1.3.0 → 1.3.1. 1.3.1 fixes the broken 1.3.0 sdist (MANIFEST.in was missing, package sources never made it into the tarball) — first buildable sdist since the feedstock migrated to the Cython recipe.

Also bumps the ubwa pin to match upstream (>=2.12.2).

@conda-forge-admin, please rerender