### PR TITLE
rebuild 1.3.1 (Azure pipelines failed on first merge)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d526603535789ae6b510676fb5425ef42e53274dcf6a3834d3c77cbdef839187
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
Azure Windows + macOS builds failed during the 1.3.1 main build because the feedstock CI setup was targeting the old cos7 base image. The rerender PR #18 fixed that but didn't retrigger a 1.3.1 rebuild. Linux (GHA) went through fine, so the conda-forge channel currently only has linux-64 binaries for 1.3.1.

Bumping build number to 1 forces a full rebuild across all platforms.