### PR TITLE
Rebuild for python 3.14 (CI race-condition recovery)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d526603535789ae6b510676fb5425ef42e53274dcf6a3834d3c77cbdef839187
 
 build:
-  number: 2
+  number: 3
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
Bumping build number to retrigger CI for the py3.14 builds that failed on the initial post-merge run due to a race condition: builds started before the upstream py3.14 packages (UBWA / UBRA) had finished uploading to conda-forge.

All required py3.14 dependencies are now live on conda-forge:
- unicorn-binance-rest-api 2.11.0 py314 (linux/osx/win)
- unicorn-binance-websocket-api 2.12.2 py314 (linux/win — osx pending similar restart)

Bot-driven `@conda-forge-admin please restart ci` does not appear to act on already-merged PRs, so this is the simplest deterministic fix.