### PR TITLE
Rebuild for python 3.14 osx (race-condition v2)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d526603535789ae6b510676fb5425ef42e53274dcf6a3834d3c77cbdef839187
 
 build:
-  number: 3
+  number: 4
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
Second rebuild — the previous one raced again on osx_64.

After the first rebuild PR was merged, the osx_64 build started before UBWA's osx-py3.14 package had finished uploading (UBWA-osx took an extra build cycle due to a separate flaky macOS SDK download). The other platforms (linux+win) succeeded.

UBWA py3.14 is now fully live on all 3 platforms (linux/osx/win), so this rebuild should pick it up cleanly. Linux+win will be rebuilt as a side effect — they will overwrite the existing higher-build-number package and is harmless.